### PR TITLE
merge: rule-tweaks to main

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,6 +63,7 @@
         ],
         plugins: ['vue'],
         rules: {
+          'unicorn/filename-case': [ 'error', { case: 'pascalCase' }],
           'vue/component-name-in-template-casing': [ 'error', 'kebab-case' ],
           'vue/component-definition-name-casing': [ 'error', 'kebab-case' ],
           'vue/singleline-html-element-content-newline': 'off',

--- a/plugins/eslint-recommended.js
+++ b/plugins/eslint-recommended.js
@@ -199,12 +199,7 @@
     'semi-spacing': [ 'error', { after: true, before: false }],
     'semi-style': [ 'error', 'last' ],
     semi: [ 'error', 'always' ],
-    'sort-imports': [
-      'error', {
-        allowSeparatedGroups: true,
-        ignoreCase: false,
-      },
-    ],
+    'sort-imports': 'off',
     'sort-vars': [ 'error', { ignoreCase: false }],
     'space-before-blocks': [ 'error', 'always' ],
     'space-before-function-paren': [ 'error', 'never' ],

--- a/plugins/node.js
+++ b/plugins/node.js
@@ -1,6 +1,8 @@
 (() => {
   'use strict';
 
+  const path = require('path');
+
   const NODE_VERSION = '>=14.0.0';
 
   module.exports = {
@@ -17,7 +19,11 @@
     'node/handle-callback-err': ['error'],
     'node/no-deprecated-api': [ 'error', { version: NODE_VERSION }],
     'node/no-missing-import': ['error'],
-    'node/no-missing-require': ['error'],
+    'node/no-missing-require': [
+      'error', {
+        resolvePaths: [path.resolve(__dirname, '../../../lambda/layers/node-modules/nodejs/node_modules')],
+      },
+    ],
     'node/no-mixed-requires': [ 'error', { allowCall: true, grouping: true }],
     'node/no-new-require': ['error'],
     'node/no-path-concat': ['error'],


### PR DESCRIPTION
Two updates:

1.  allows for standard naming of vue files `MyComponent.vue` not `my-component.vue`
2. should no longer require us to disable `node/missing-require` rules when using `require` for a node module in our lambda layers.