### PR TITLE
merge: object-property-newline to dev

### DIFF
--- a/plugins/eslint-recommended.js
+++ b/plugins/eslint-recommended.js
@@ -133,9 +133,16 @@
     'no-with': ['error'],
     'nonblock-statement-body-position': [ 'error', 'beside' ],
     'object-curly-newline': [
-      'error', {
-        ObjectExpression: { consistent: true },
-        ObjectPattern: { consistent: true },
+      'error',
+      {
+        ObjectExpression: {
+          multiline: true,
+          minProperties: 1
+        },
+        ObjectPattern: {
+          consistent: true,
+          minProperties: 1
+        },
         ImportDeclaration: 'always',
         ExportDeclaration: 'always',
       },
@@ -146,6 +153,7 @@
         objectsInObjects: false,
       },
     ],
+    'object-property-newline': ['error'],
     'object-shorthand': ['error'],
     'one-var-declaration-per-line': ['error'],
     'one-var': [ 'error', 'never' ],


### PR DESCRIPTION
@simplesenseio/tools The build is broken because this change causes linting changes, but I didn't want the actual change to get lost in them. So I have this doing to `dev` and then I'll commit to `dev` after with all the linting changes to validate the build.